### PR TITLE
Added Builder ops for conveniently chaining builder class setters

### DIFF
--- a/src/main/scala/springnz/util/BuilderOps.scala
+++ b/src/main/scala/springnz/util/BuilderOps.scala
@@ -2,7 +2,7 @@ package springnz.util
 
 object BuilderOps {
   implicit class ReqBuilderOps[A](builder: A) {
-    def setOptional[B](value: Option[B], setMethod: (A, B) ⇒ A) = value match {
+    def setIfSome[B](value: Option[B], setMethod: (A, B) ⇒ A) = value match {
       case None             ⇒ builder
       case Some(innerValue) ⇒ setMethod(builder, innerValue)
     }

--- a/src/main/scala/springnz/util/BuilderOps.scala
+++ b/src/main/scala/springnz/util/BuilderOps.scala
@@ -1,0 +1,15 @@
+package springnz.util
+
+object BuilderOps {
+  implicit class ReqBuilderOps[A](builder: A) {
+    def setOptional[B](value: Option[B], setMethod: (A, B) ⇒ A) = value match {
+      case None             ⇒ builder
+      case Some(innerValue) ⇒ setMethod(builder, innerValue)
+    }
+
+    def setIfNonEmpty(value: String, setMethod: (A, String) ⇒ A) =
+      if (value.isEmpty) builder else setMethod(builder, value)
+  }
+}
+
+

--- a/src/test/scala/springnz/util/BuilderOpsTest.scala
+++ b/src/test/scala/springnz/util/BuilderOpsTest.scala
@@ -7,13 +7,13 @@ class BuilderOpsTest extends WordSpec with ShouldMatchers {
   "BuilderOps" should {
     "be applied for Somes" in {
       val list = List("C", "B", "A")
-      val newList = list.setOptional[String](Some("D"), (list, value) => value :: list)
+      val newList = list.setIfSome[String](Some("D"), (list, value) => value :: list)
       newList shouldBe List("D", "C", "B", "A")
     }
 
     "leave the instance unchanged for Nones" in {
       val list = List[String]("C", "B", "A")
-      val newList = list.setOptional[String](None, (list, value) => value :: list)
+      val newList = list.setIfSome[String](None, (list, value) => value :: list)
       newList should be theSameInstanceAs list
     }
 

--- a/src/test/scala/springnz/util/BuilderOpsTest.scala
+++ b/src/test/scala/springnz/util/BuilderOpsTest.scala
@@ -1,0 +1,32 @@
+package springnz.util
+
+import org.scalatest._
+
+class BuilderOpsTest extends WordSpec with ShouldMatchers {
+  import BuilderOps._
+  "BuilderOps" should {
+    "be applied for Somes" in {
+      val list = List("C", "B", "A")
+      val newList = list.setOptional[String](Some("D"), (list, value) => value :: list)
+      newList shouldBe List("D", "C", "B", "A")
+    }
+
+    "leave the instance unchanged for Nones" in {
+      val list = List[String]("C", "B", "A")
+      val newList = list.setOptional[String](None, (list, value) => value :: list)
+      newList should be theSameInstanceAs list
+    }
+
+    "be applied for Non emptys" in {
+      val list = List("C", "B", "A")
+      val newList = list.setIfNonEmpty("D", (list, value) => value :: list)
+      newList shouldBe List("D", "C", "B", "A")
+    }
+
+    "leave the instance unchanged for non-empties" in {
+      val list = List[String]("C", "B", "A")
+      val newList = list.setIfNonEmpty("", (list, value) => value :: list)
+      newList should be theSameInstanceAs list
+    }
+  }
+}

--- a/src/test/scala/springnz/util/TryListPimperTest.scala
+++ b/src/test/scala/springnz/util/TryListPimperTest.scala
@@ -33,3 +33,5 @@ class TryListPimperTest extends WordSpec with ShouldMatchers {
     }
   }
 }
+
+

--- a/src/test/scala/springnz/util/TryListPimperTest.scala
+++ b/src/test/scala/springnz/util/TryListPimperTest.scala
@@ -33,5 +33,3 @@ class TryListPimperTest extends WordSpec with ShouldMatchers {
     }
   }
 }
-
-


### PR DESCRIPTION
Added Builder ops for conveniently chaining builder class setters
 (where you want to do nothing for Nones)

Test case coverage is fine, but this is how you would use it in practise:

``` scala
val request: SearchRequestBuilder = new SearchRequestBuilder(client, SearchAction.INSTANCE)
  .setSearchType(SearchType.DEFAULT)
  .setIndices("solverdata")
  .setTypes("all")
  .setIfSome(page.from, (builder, value) ⇒ builder.setFrom(value))
  .setIfSome(page.size, (builder, value) ⇒ builder.setSize(value))
  .setIfNonEmpty(queryString, (builder, value) ⇒ builder.setQuery(value))
```
